### PR TITLE
Fix: Route authentication logs to Eclipse Error Log (AST-136023)

### DIFF
--- a/checkmarx-ast-eclipse-plugin-tests/src/test/java/checkmarx/ast/eclipse/plugin/tests/unit/runner/AuthenticatorTest.java
+++ b/checkmarx-ast-eclipse-plugin-tests/src/test/java/checkmarx/ast/eclipse/plugin/tests/unit/runner/AuthenticatorTest.java
@@ -34,7 +34,7 @@ class AuthenticatorTest {
             String result = authenticator.doAuthentication("dummyKey", "--param");
 
             assertEquals("SUCCESS", result);
-            mockedCxLogger.verify(() -> CxLogger.info("Authentication Status: SUCCESS"));
+            mockedCxLogger.verify(() -> CxLogger.info(String.format(PluginConstants.INFO_AUTHENTICATION_STATUS, "SUCCESS")));
         }
     }
 

--- a/checkmarx-ast-eclipse-plugin-tests/src/test/java/checkmarx/ast/eclipse/plugin/tests/unit/runner/AuthenticatorTest.java
+++ b/checkmarx-ast-eclipse-plugin-tests/src/test/java/checkmarx/ast/eclipse/plugin/tests/unit/runner/AuthenticatorTest.java
@@ -7,12 +7,14 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
 import com.checkmarx.ast.wrapper.CxException;
 import com.checkmarx.ast.wrapper.CxWrapper;
 import com.checkmarx.eclipse.runner.Authenticator;
+import com.checkmarx.eclipse.utils.CxLogger;
 import com.checkmarx.eclipse.utils.PluginConstants;
 
 class AuthenticatorTest {
@@ -24,14 +26,15 @@ class AuthenticatorTest {
 
         try (MockedConstruction<CxWrapper> mocked =
                      Mockito.mockConstruction(CxWrapper.class,
-                             (mock, context) -> when(mock.authValidate()).thenReturn("SUCCESS"))) {
+                             (mock, context) -> when(mock.authValidate()).thenReturn("SUCCESS"));
+             MockedStatic<CxLogger> mockedCxLogger = Mockito.mockStatic(CxLogger.class)) {
 
             Authenticator authenticator = new Authenticator(mockLogger);
 
             String result = authenticator.doAuthentication("dummyKey", "--param");
 
             assertEquals("SUCCESS", result);
-            verify(mockLogger).info("Authentication Status: SUCCESS");
+            mockedCxLogger.verify(() -> CxLogger.info("Authentication Status: SUCCESS"));
         }
     }
 
@@ -43,17 +46,18 @@ class AuthenticatorTest {
         try (MockedConstruction<CxWrapper> mocked =
                      Mockito.mockConstruction(CxWrapper.class,
                              (mock, context) -> when(mock.authValidate())
-                                     .thenThrow(new IOException("IO error")))) {
+                                     .thenThrow(new IOException("IO error")));
+             MockedStatic<CxLogger> mockedCxLogger = Mockito.mockStatic(CxLogger.class)) {
 
             Authenticator authenticator = new Authenticator(mockLogger);
 
             String result = authenticator.doAuthentication("dummyKey", "--param");
 
             assertEquals("IO error", result);
-            verify(mockLogger).error(
-            	    eq(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, "IO error")),
-            	    any(IOException.class)
-            	);
+            mockedCxLogger.verify(() -> CxLogger.error(
+                    eq(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, "IO error")),
+                    any(IOException.class)
+            ));
         }
     }
 
@@ -65,17 +69,18 @@ class AuthenticatorTest {
         try (MockedConstruction<CxWrapper> mocked =
                      Mockito.mockConstruction(CxWrapper.class,
                              (mock, context) -> when(mock.authValidate())
-                                     .thenThrow(new InterruptedException("Interrupted")))) {
+                                     .thenThrow(new InterruptedException("Interrupted")));
+             MockedStatic<CxLogger> mockedCxLogger = Mockito.mockStatic(CxLogger.class)) {
 
             Authenticator authenticator = new Authenticator(mockLogger);
 
             String result = authenticator.doAuthentication("dummyKey", "--param");
 
             assertEquals("Interrupted", result);
-            verify(mockLogger).error(
-            	    eq(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, "Interrupted")),
-            	    any(InterruptedException.class)
-            	);
+            mockedCxLogger.verify(() -> CxLogger.error(
+                    eq(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, "Interrupted")),
+                    any(InterruptedException.class)
+            ));
         }
     }
 
@@ -87,17 +92,18 @@ class AuthenticatorTest {
         try (MockedConstruction<CxWrapper> mocked =
                      Mockito.mockConstruction(CxWrapper.class,
                              (mock, context) -> when(mock.authValidate())
-                                     .thenThrow(new CxException(1, "Cx error")))) {
+                                     .thenThrow(new CxException(1, "Cx error")));
+             MockedStatic<CxLogger> mockedCxLogger = Mockito.mockStatic(CxLogger.class)) {
 
             Authenticator authenticator = new Authenticator(mockLogger);
 
             String result = authenticator.doAuthentication("dummyKey", "--param");
 
             assertEquals("Cx error", result);
-            verify(mockLogger).error(
-            	    eq(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, "Cx error")),
-            	    any(CxException.class)
-            	);
+            mockedCxLogger.verify(() -> CxLogger.error(
+                    eq(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, "Cx error")),
+                    any(CxException.class)
+            ));
         }
     }
 

--- a/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/runner/Authenticator.java
+++ b/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/runner/Authenticator.java
@@ -33,10 +33,10 @@ public class Authenticator {
 	       try {
 	           CxWrapper wrapper = new CxWrapper(config, log);
 	           String cxValidateOutput = wrapper.authValidate();
-	           log.info(AUTH_STATUS + cxValidateOutput);
+	           CxLogger.info(AUTH_STATUS + cxValidateOutput);
 	           return cxValidateOutput;
 	       } catch (IOException | InterruptedException | CxException e) {
-	           log.error(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, e.getMessage()), e);
+	           CxLogger.error(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, e.getMessage()), e);
 	           return e.getMessage();
 	       }
 	   }

--- a/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/runner/Authenticator.java
+++ b/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/runner/Authenticator.java
@@ -33,7 +33,7 @@ public class Authenticator {
 	       try {
 	           CxWrapper wrapper = new CxWrapper(config, log);
 	           String cxValidateOutput = wrapper.authValidate();
-	           CxLogger.info(AUTH_STATUS + cxValidateOutput);
+	           CxLogger.info(String.format(PluginConstants.INFO_AUTHENTICATION_STATUS, cxValidateOutput));
 	           return cxValidateOutput;
 	       } catch (IOException | InterruptedException | CxException e) {
 	           CxLogger.error(String.format(PluginConstants.ERROR_AUTHENTICATING_AST, e.getMessage()), e);


### PR DESCRIPTION
Replace SLF4J log calls in Authenticator.doAuthentication() with CxLogger so auth success/failure messages appear in .metadata/.log and the Eclipse Error Log UI instead of being silently dropped.

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used