### PR TITLE
Fix: Clear detail panels on severity filter change (AST-136035)

### DIFF
--- a/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/CheckmarxView.java
+++ b/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/CheckmarxView.java
@@ -160,6 +160,7 @@ public class CheckmarxView extends ViewPart implements EventHandler {
 	private Text commentText;
 	private DisplayModel rootModel;
 	private String selectedSeverity, selectedState;
+	private DisplayModel currentlyDisplayedItem;
 	private Button triageButton;
 	private SelectionAdapter triageButtonAdapter, codeBashingAdapter;
 	private Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
@@ -1385,6 +1386,7 @@ public class CheckmarxView extends ViewPart implements EventHandler {
 
 							if (selectedItem.getResult() != null && selectedItem.getResult().getSimilarityId() != null) {
 								sync.asyncExec(() -> {
+									currentlyDisplayedItem = selectedItem;
 									createTriageSeverityAndStateCombos(selectedItem);
 									populateTriageChanges(selectedItem);
 									resultViewComposite.setVisible(true);
@@ -2488,8 +2490,12 @@ public class CheckmarxView extends ViewPart implements EventHandler {
 
 	private void updateResultsTree(List<DisplayModel> results, boolean expand) {
 		sync.asyncExec(() -> {
-			resultViewComposite.setVisible(false);
-			attackVectorCompositePanel.setVisible(false);
+			if (currentlyDisplayedItem == null
+					|| currentlyDisplayedItem.getSeverity() == null
+					|| !FilterState.isSeverityEnabled(currentlyDisplayedItem.getSeverity())) {
+				resultViewComposite.setVisible(false);
+				attackVectorCompositePanel.setVisible(false);
+			}
 			rootModel.children.clear();
 			rootModel.children.addAll(results);
 			Object[] expanded = resultsTree.getExpandedElements();

--- a/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/CheckmarxView.java
+++ b/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/CheckmarxView.java
@@ -2474,6 +2474,8 @@ public class CheckmarxView extends ViewPart implements EventHandler {
 	private void listener(PluginListenerDefinition definition) {
 		switch (definition.getListenerType()) {
 			case FILTER_CHANGED:
+				updateResultsTree(definition.getResutls(), true);
+				break;
 			case GET_RESULTS:
 				updateResultsTree(definition.getResutls(), false);
 				break;
@@ -2496,9 +2498,9 @@ public class CheckmarxView extends ViewPart implements EventHandler {
 				resultViewComposite.setVisible(false);
 				attackVectorCompositePanel.setVisible(false);
 			}
+			Object[] expanded = resultsTree.getExpandedElements();
 			rootModel.children.clear();
 			rootModel.children.addAll(results);
-			Object[] expanded = resultsTree.getExpandedElements();
 			resultsTree.refresh();
 			if (expand) {
 				Set<String> expandedDMNames = new HashSet<>();

--- a/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/CheckmarxView.java
+++ b/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/CheckmarxView.java
@@ -1082,8 +1082,7 @@ public class CheckmarxView extends ViewPart implements EventHandler {
 		scanIdComboViewer.setContentProvider(ArrayContentProvider.getInstance());
 		scanIdComboViewer.setInput(new ArrayList<>());
 
-		GridData gridData = new GridData();
-		gridData.widthHint = 520;
+		GridData gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
 		scanIdComboViewer.getCombo().setLayoutData(gridData);
 
 		scanIdComboViewer.getCombo().addListener(SWT.DefaultSelection, new Listener() {
@@ -2489,6 +2488,8 @@ public class CheckmarxView extends ViewPart implements EventHandler {
 
 	private void updateResultsTree(List<DisplayModel> results, boolean expand) {
 		sync.asyncExec(() -> {
+			resultViewComposite.setVisible(false);
+			attackVectorCompositePanel.setVisible(false);
 			rootModel.children.clear();
 			rootModel.children.addAll(results);
 			Object[] expanded = resultsTree.getExpandedElements();


### PR DESCRIPTION
…an ID combo overflow

- Hide resultViewComposite and attackVectorCompositePanel when filter changes so the description and attack vector windows no longer show stale content
- Replace fixed widthHint=520 on scan ID combo with SWT.FILL/grabExcess layout so the combo is always visible without needing to maximize the window

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used