### PR TITLE
Fix: Truncate long custom state names in filter menu (AST-137779)

### DIFF
--- a/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/CheckmarxView.java
+++ b/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/CheckmarxView.java
@@ -626,6 +626,13 @@ public class CheckmarxView extends ViewPart implements EventHandler {
 		combo_1.setLayoutData(gd_combo_1);
 
 		triageStateComboViewer = new ComboViewer(triageView, SWT.READ_ONLY);
+		triageStateComboViewer.setLabelProvider(new LabelProvider() {
+			@Override
+			public String getText(Object element) {
+				String s = element instanceof String ? (String) element : super.getText(element);
+				return s.length() > 50 ? s.substring(0, 47) + "..." : s;
+			}
+		});
 		Combo combo_2 = triageStateComboViewer.getCombo();
 		combo_2.setEnabled(true);
 		combo_2.setData(PluginConstants.DATA_ID_KEY, PluginConstants.TRIAGE_STATE_COMBO_ID);

--- a/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/actions/ActionFilterStatePreference.java
+++ b/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/actions/ActionFilterStatePreference.java
@@ -89,7 +89,7 @@ class ActionFilterStatePreference extends Action implements IMenuCreator {
 
 		for (String customState : customStates) {
 			MenuItem item = new MenuItem(menu, SWT.CHECK);
-			item.setText(customState);
+			item.setText(truncate(customState));
 			item.setSelection(FilterState.isCustomStateSelected(customState));
 			item.addSelectionListener(new SelectionAdapter() {
 				@Override
@@ -126,5 +126,9 @@ class ActionFilterStatePreference extends Action implements IMenuCreator {
 	@Override
 	public Menu getMenu(final Menu parent) {
 		return null;
+	}
+
+	private static String truncate(String text) {
+		return text.length() > 50 ? text.substring(0, 47) + "..." : text;
 	}
 }

--- a/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/actions/ActionStartScan.java
+++ b/checkmarx-ast-eclipse-plugin/src/com/checkmarx/eclipse/views/actions/ActionStartScan.java
@@ -220,7 +220,7 @@ public class ActionStartScan extends CxBaseAction {
 	 */
 	private boolean cxProjectMatchesWorkspaceProject() {
 		Results results = DataProvider.getInstance().getCurrentResults();
-		boolean noResultsInScan = results == null || results.getResults().isEmpty();
+		boolean noResultsInScan = results == null || results.getResults() == null || results.getResults().isEmpty();
 		boolean noFilesInWorkspace = ResourcesPlugin.getWorkspace().getRoot().getProjects().length == 0;
 
 		if (noResultsInScan || noFilesInWorkspace) {


### PR DESCRIPTION
…riage combo

Custom states with very long names caused the state filter dropdown menu to expand across the entire screen. Fix truncates display text to 50 chars (with trailing "...") in both the state filter MenuItem and the triage state ComboViewer LabelProvider. The full state name is still used internally for filtering and triage submission.

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used