### PR TITLE
fix(actions): declare secrets used by reusable workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         description: 'Jira ticket ID (e.g. AST-12345)'
         required: true
         type: string
+    secrets:
+      ECLIPSE_SITE_TOKEN:
+        required: true
+      PERSONAL_ACCESS_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Adds explicit on.workflow_call.secrets declarations for all secrets referenced in the workflow body, replacing implicit reliance on callers using secrets: inherit.